### PR TITLE
add filtering

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -66,7 +66,7 @@ See also [`unique_ips`](@ref).
 lineinfodict(s::Set) = lineinfodict(collect(s))
 
 """
-    g = flamegraph(data=Profile.fetch(); lidict=nothing, C=false, combine=true, recur=:off, norepl=true, pruned=[])
+    g = flamegraph(data=Profile.fetch(); lidict=nothing, C=false, combine=true, recur=:off, norepl=true, pruned=[], filter=nothing)
 
 Compute a graph representing profiling data. To compute it for the currently-collected
 profiling information, omit both `data` and `lidict`; if you are computing it for saved
@@ -84,11 +84,16 @@ You can control the strategy with the following keywords:
   `sort!` function and anything called by it. See also `recur` for an alternative strategy.
 - `combine`: if true, instruction pointers that correspond to the same line of code are
   combined into a single stackframe
+- `filter`: drop all branches that do not satisfy the filter condition. `Condition` can be `string`, `regex`
+  or any function, that can be applied to `NodeData`. For example, `filter = "mapslices"` or equivalently
+  `filter = x -> (x.sf.func == :mapslices)` removes all branches that do not contain `mapslices` Node as a child
+  or ancestor.
 
 `g` can be inspected using [`AbstractTrees.jl`'s](https://github.com/JuliaCollections/AbstractTrees.jl)
 `print_tree`.
 """
-function flamegraph(data=Profile.fetch(); lidict=nothing, C=false, combine=true, recur=:off, norepl=true, pruned=defaultpruned)
+function flamegraph(data=Profile.fetch(); lidict=nothing, C=false, combine=true,
+        recur=:off, norepl=true, pruned=defaultpruned, filter=nothing)
     if lidict === nothing
         lidict = lineinfodict(unique(data))
     end
@@ -110,6 +115,11 @@ function flamegraph(data=Profile.fetch(); lidict=nothing, C=false, combine=true,
     if norepl
         prunerepl!(g)
     end
+
+    if filter != nothing
+        filtergraph!(g, filter)
+    end
+
     return g
 end
 
@@ -136,6 +146,39 @@ function status(sf::StackFrame)
         st |= repl
     end
     return st
+end
+
+function Base.:occursin(needle::Union{AbstractString,Regex,AbstractChar}, g::Node)
+    return occursin(needle, string(g.data.sf))
+end
+
+function Base.:occursin(needle::Function, g::Node)
+    return needle(g.data)
+end
+
+function canfind(needle, g::Node, memo = Dict{Node, Bool}())
+    haskey(memo, g) && return memo[g]
+    if occursin(needle, g)
+        memo[g] = true
+    else
+        memo[g] = any(canfind(needle, child, memo) for child in g)
+    end
+    return memo[g]
+end
+
+function filtergraph!(g::Node, filter, memo = Dict{Node, Bool}())
+    if !canfind(filter, g, memo)
+        if isroot(g)
+            @warn "The filter condition results in the root node pruning, so the filter is ignored"
+        else
+            prunebranch!(g)
+        end
+    else
+        for child in g
+            occursin(filter, child) && continue
+            filtergraph!(child, filter, memo)
+        end
+    end
 end
 
 function flamegraph!(graph, ptree; C=false, pruned=defaultpruned, hstart=first(graph.data.span))

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -148,17 +148,17 @@ function status(sf::StackFrame)
     return st
 end
 
-function Base.:occursin(needle::Union{AbstractString,Regex,AbstractChar}, g::Node)
+function nodematches(needle::Union{AbstractString,Regex,AbstractChar}, g::Node)
     return occursin(needle, string(g.data.sf))
 end
 
-function Base.:occursin(needle::Function, g::Node)
+function nodematches(needle::Function, g::Node)
     return needle(g.data)
 end
 
 function canfind(needle, g::Node, memo = Dict{Node, Bool}())
     haskey(memo, g) && return memo[g]
-    if occursin(needle, g)
+    if nodematches(needle, g)
         memo[g] = true
     else
         memo[g] = any(canfind(needle, child, memo) for child in g)
@@ -175,7 +175,7 @@ function filtergraph!(g::Node, filter, memo = Dict{Node, Bool}())
         end
     else
         for child in g
-            occursin(filter, child) && continue
+            nodematches(filter, child) && continue
             filtergraph!(child, filter, memo)
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,10 +8,10 @@ stackframe(func, file, line; C=false) = StackFrame(Symbol(func), Symbol(file), l
 
 @testset "flamegraph" begin
     backtraces = UInt64[0, 4, 3, 2, 1,   # order: calles then caller
-    0, 6, 5, 1,
-    0, 8, 7,
-    0, 4, 3, 2, 1,
-    0]
+                        0, 6, 5, 1,
+                        0, 8, 7,
+                        0, 4, 3, 2, 1,
+                        0]
     lidict = Dict{UInt64,StackFrame}(1=>stackframe(:f1, :file1, 1),
                                      2=>stackframe(:f2, :file1, 5),
                                      3=>stackframe(:f3, :file2, 1),
@@ -155,10 +155,10 @@ end
 
 @testset "flamegraph string filtering" begin
     backtraces = UInt64[0, 4, 3, 2, 1,   # order: calles then caller
-        0, 6, 5, 1,
-        0, 8, 7,
-        0, 4, 3, 2, 1,
-        0]
+                        0, 6, 5, 1,
+                        0, 8, 7,
+                        0, 4, 3, 2, 1,
+                        0]
     lidict = Dict{UInt64,StackFrame}(1=>stackframe(:f1, :file1, 1),
                                      2=>stackframe(:f2, :file1, 5),
                                      3=>stackframe(:f3, :file2, 1),
@@ -197,10 +197,10 @@ end
 
 @testset "flamegraph function filtering" begin
     backtraces = UInt64[0, 4, 3, 2, 1,   # order: calles then caller
-        0, 6, 5, 1,
-        0, 8, 7,
-        0, 4, 3, 2, 1,
-        0]
+                        0, 6, 5, 1,
+                        0, 8, 7,
+                        0, 4, 3, 2, 1,
+                        0]
 
     lidict = Dict{UInt64,StackFrame}(1=>stackframe(:f1, :file1, 1),
                                      2=>stackframe(:f2, :file1, 5),
@@ -253,10 +253,10 @@ end
 
 @testset "flamegraph wrong filtering is ignored" begin
     backtraces = UInt64[0, 4, 3, 2, 1,   # order: calles then caller
-        0, 6, 5, 1,
-        0, 8, 7,
-        0, 4, 3, 2, 1,
-        0]
+                        0, 6, 5, 1,
+                        0, 8, 7,
+                        0, 4, 3, 2, 1,
+                        0]
 
     lidict = Dict{UInt64,StackFrame}(1=>stackframe(:f1, :file1, 1),
                                      2=>stackframe(:f2, :file1, 5),


### PR DESCRIPTION
As it was discussed in https://github.com/timholy/FlameGraphs.jl/issues/11, it is the implementation of filtering feature. Actually, I am not sure that `filter` is the correct word here, but I suppose it's ok.

The main idea is that sometimes one has a function and there is a suspicious function call, which requires more detailed investigation. In this case, it could be useful to leave only those parts of the tree that contains this call, removing everything else.

Consider for example `profile_test` scenario. 
```julia
function profile_test(n)
    for i = 1:n
        A = randn(100,100,20)
        m = maximum(A)
        Am = mapslices(sum, A; dims=2)
        B = A[:,:,5]
        Bsort = mapslices(sort, B; dims=1)
        b = rand(100)
        C = B.*b
    end
end
```
FlameGraph of this function contains lots of branches, but one may be interested only in `mapslices` branches. Below attached screenshots without and with filter function (do not look at the colours, it's ProfileVega bug).

Original
![original](https://user-images.githubusercontent.com/2630519/74088004-5766df00-4a9a-11ea-8b0a-824a6152815c.png)

Filtered
![filtered](https://user-images.githubusercontent.com/2630519/74088006-5c2b9300-4a9a-11ea-9fdd-1875729b5506.png)

