### PR TITLE
Add support for 32-bit systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,15 @@ julia:
   - 1.0
   - 1
   - nightly
-# matrix:
-#   allow_failures:
-#     - julia: nightly
-#   fast_finish: true
 notifications:
   email: false
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 jobs:
   include:
+    - julia: 1
+      os: linux
+      arch: x86
     - stage: "Documentation"
       julia: 1
       os: linux

--- a/src/io.jl
+++ b/src/io.jl
@@ -17,15 +17,16 @@ If you just supply a string filename ending with this extension,
 you must pass `data` and `lidict` explicitly, because
 FileIO has its own interpretation of the meaning of `save` with no arguments.
 """
-function save(f::File{format"JLPROF"}, data::AbstractVector{UInt64}, lidict::Profile.LineInfoDict)
+function save(f::File{format"JLPROF"}, data::AbstractVector{<:Unsigned}, lidict::Profile.LineInfoDict)
+    data_u64 = convert(AbstractVector{UInt64}, data)
     open(f, "w") do io
         write(io, magic(format"JLPROF"))
         # Write an endianness revealer
         write(io, 0x01020304)
         # Write an indicator that this is data/lidict format
         write(io, 0x01)
-        write(io, Int64(length(data)))
-        write(io, data)
+        write(io, Int64(length(data_u64)))
+        write(io, data_u64)
         write(io, Int64(length(lidict)))
         for (k, v) in lidict
             write(io, k)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Test, Profile
 # useful for testing
 stackframe(func, file, line; C=false) = StackFrame(Symbol(func), Symbol(file), line, nothing, C, false, 0)
 
+Profile.init(n=10000) # prevent stack overflow
 
 @testset "flamegraph" begin
     backtraces = UInt64[0, 4, 3, 2, 1,   # order: calles then caller
@@ -406,18 +407,18 @@ end
 end
 
 @testset "Profiling" begin
-     A = randn(100, 100, 200)
-     Profile.clear()
-     @profile mapslices(sum, A; dims=2)
-     g = flamegraph()
-     @test FlameGraphs.depth(g) > 10
-     img = flamepixels(StackFrameCategory(), flamegraph(C=true))
-     @test any(img .== colorant"orange")
-     A = [1,2,3]
-     sum(A)
-     Profile.clear()
-     @profile sum(A)
-     Sys.islinux() && @test_logs (:warn, r"There were no samples collected.") flamegraph() === nothing
+    A = randn(100, 100, 200)
+    Profile.clear()
+    @profile mapslices(sum, A; dims=2)
+    g = flamegraph()
+    @test FlameGraphs.depth(g) > 10
+    img = flamepixels(StackFrameCategory(), flamegraph(C=true))
+    @test any(img .== colorant"orange")
+    A = [1,2,3]
+    sum(A)
+    Profile.clear()
+    @profile sum(A)
+    Sys.islinux() && @test_logs (:warn, r"There were no samples collected.") flamegraph() === nothing
 end
 
 @testset "IO" begin


### PR DESCRIPTION
This fixes #28.

~This also fixes the potential stack overflow of `status()`. However, `flamegraph!()` can still cause a stack overflow. So, we can also remove the change from this PR.~

Profiling on 32-bit systems seems to be "somewhat" different than on 64-bit systems.