### PR TITLE
Add PProf to the list of packages that support `FlameGraphs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ FlameGraphs is a package that adds functionality to Julia's `Profile` standard l
 You might use FlameGraphs on its own, but users should consider one of its downstream packages:
 
 - [ProfileView](https://github.com/timholy/ProfileView.jl), a graphical user interface (GUI) based on [Gtk](https://github.com/JuliaGraphics/Gtk.jl) for displaying and interacting with flame graphs
+- [PProf](https://github.com/JuliaPerf/PProf.jl), an interactive, web-based profile GUI explorer, implemented as a wrapper around [`google/pprof`](https://github.com/google/pprof). Has excellent support for interaction, filtering, aggregation, and viewing source code. But note that it loses the sample ordering information captured in FlameGraphs.
 - [Juno](https://junolab.org/), a development environment that supports profile visualization
 - [ProfileVega](https://github.com/davidanthoff/ProfileVega.jl), the recommended package for display in Jupyter notebooks
 - [ProfileSVG](https://github.com/timholy/ProfileSVG.jl), a package for writing flame graphs to SVG format
-- [PProf](https://github.com/JuliaPerf/PProf.jl), an interactive, web-based profile GUI explorer, implemented as a wrapper around [`google/pprof`](https://github.com/google/pprof). Has excellent support for interaction, filtering, aggregation, and viewing source code. But note that it loses the sample ordering information captured in FlameGraphs.
 
 See the documentation for details.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You might use FlameGraphs on its own, but users should consider one of its downs
 - [Juno](https://junolab.org/), a development environment that supports profile visualization
 - [ProfileVega](https://github.com/davidanthoff/ProfileVega.jl), the recommended package for display in Jupyter notebooks
 - [ProfileSVG](https://github.com/timholy/ProfileSVG.jl), a package for writing flame graphs to SVG format
+- [PProf](https://github.com/JuliaPerf/PProf.jl), an interactive, web-based profile GUI explorer, implemented as a wrapper around [`google/pprof`](https://github.com/google/pprof).
 
 See the documentation for details.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You might use FlameGraphs on its own, but users should consider one of its downs
 - [Juno](https://junolab.org/), a development environment that supports profile visualization
 - [ProfileVega](https://github.com/davidanthoff/ProfileVega.jl), the recommended package for display in Jupyter notebooks
 - [ProfileSVG](https://github.com/timholy/ProfileSVG.jl), a package for writing flame graphs to SVG format
-- [PProf](https://github.com/JuliaPerf/PProf.jl), an interactive, web-based profile GUI explorer, implemented as a wrapper around [`google/pprof`](https://github.com/google/pprof).
+- [PProf](https://github.com/JuliaPerf/PProf.jl), an interactive, web-based profile GUI explorer, implemented as a wrapper around [`google/pprof`](https://github.com/google/pprof). Has excellent support for interaction, filtering, aggregation, and viewing source code. But note that it loses the sample ordering information captured in FlameGraphs.
 
 See the documentation for details.
 


### PR DESCRIPTION
As of https://github.com/JuliaPerf/PProf.jl/pull/25, and release v1.2.0, PProf.jl has supported displaying FlameGraphs directly, via:
```julia
using PProf
pprof(fg)
```

I'm not sure of what order to put this in. I put it last, since it's the newest, but I'd probably prefer to put it either right below ProfileView or right below Juno, since it's one of the main interactive profile viewers in julia, whereas the others are either specific to exporting or specific to notebooks. :) Thanks!