### PR TITLE
Fix runtime dispatch detection on nightly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 [compat]
 AbstractTrees = "0.3"
 Colors = "0.9, 0.10, 0.11, 0.12"
-FileIO = "1.2.2"
+FileIO = "1.6"
 FixedPointNumbers = "0.6.1, 0.7, 0.8"
 IndirectArrays = "0.5"
 LeftChildRightSiblingTrees = "0.1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,8 @@ LeftChildRightSiblingTrees = "0.1.1"
 julia = "1"
 
 [extras]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["InteractiveUtils", "Test"]

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -139,7 +139,7 @@ end
 
 function status(sf::StackFrame)
     st = UInt8(0)
-    if sf.from_c && (sf.func === :jl_invoke || sf.func === :jl_apply_generic)
+    if sf.from_c && (sf.func === :jl_invoke || sf.func === :jl_apply_generic || sf.func === :ijl_apply_generic)
         st |= runtime_dispatch
     end
     if sf.from_c && startswith(String(sf.func), "jl_gc_")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -468,7 +468,7 @@ end
     Profile.clear()
     @profile mapslices(sum, A; dims=2)
     fn = tempname()*".jlprof"
-    f = File(format"JLPROF", fn)
+    f = File{format"JLPROF"}(fn)
     FlameGraphs.save(f)
     data, lidict = FlameGraphs.load(f)
     datar, lidictr = Profile.retrieve()


### PR DESCRIPTION
Starting with 1.8.0-DEV.600, Julia split the internal and external names in the C library. This tests for detection of runtime dispatch and fixes a SnoopCompile failure on nightly.

For good measure, this also throws in a fix for a FileIO depwarn that occurs only in the tests.
