### PR TITLE
Enhance the default FlameColors: Highlight compilation. De-highlight waiting tasks

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -27,6 +27,8 @@ end
 const runtime_dispatch = UInt8(1)
 const gc_event         = UInt8(2)
 const repl             = UInt8(4)
+const compilation      = UInt8(8)
+const task_event       = UInt8(16)
 
 const defaultpruned = Tuple{Symbol,Symbol}[]
 
@@ -147,6 +149,12 @@ function status(sf::StackFrame)
     end
     if !sf.from_c && sf.func === :eval_user_input && endswith(String(sf.file), "REPL.jl")
         st |= repl
+    end
+    if !sf.from_c && occursin("./compiler/", String(sf.file))
+        st |= compilation
+    end
+    if !sf.from_c && occursin("task.jl", String(sf.file))
+        st |= task_event
     end
     return st
 end


### PR DESCRIPTION
The heuristics and color selection might be improvable, but the concept is to highlight compilation work (blue) and de-highlight sleeping tasks (light gray)

![Screenshot from 2022-01-06 22-09-27](https://user-images.githubusercontent.com/1694067/148485324-6d7a94da-3acc-44b4-a473-f1b08a5cd093.png)
![Screenshot from 2022-01-06 22-09-10](https://user-images.githubusercontent.com/1694067/148485325-3a19bea0-fd77-4693-bcb6-34ce01fff048.png)

