### PR TITLE
Add `darkmode` kwarg to FlameColors and `default_colors_dark`

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -34,10 +34,10 @@ single color, the specified color is always used.
 While the return value is a `struct`, it is callable and can be used as the
 `fcolor` input for `flamepixels`.
 """
-function FlameColors(n::Integer=2;
-                     colorbg=colorant"white", colorfont=colorant"black",
-                     colorsrt=colorant"crimson", colorsgc=colorant"orange",
-                     darkmode=false)
+function FlameColors(n::Integer=2; darkmode = false,
+                     colorbg=(darkmode ? RGB(0.09,0.09,0.09) : colorant"white"),
+                     colorfont=(darkmode ? colorant"white" : colorant"black"),
+                     colorsrt=colorant"crimson", colorsgc=colorant"orange")
     seeds = [colorbg, colorfont]
     function make_variations(color)
         color === nothing && return RGB{N0f8}[]
@@ -63,7 +63,7 @@ function FlameColors(n::Integer=2;
 end
 
 const default_colors = FlameColors()
-const default_colors_dark = FlameColors(; colorbg=RGB(0.09,0.09,0.09), colorfont=colorant"white", darkmode = true)
+const default_colors_dark = FlameColors(; darkmode = true)
 
 function (colors::FlameColors)(s::Symbol)
     s === :bg && return colors.colorbg

--- a/src/render.jl
+++ b/src/render.jl
@@ -36,7 +36,8 @@ While the return value is a `struct`, it is callable and can be used as the
 """
 function FlameColors(n::Integer=2;
                      colorbg=colorant"white", colorfont=colorant"black",
-                     colorsrt=colorant"crimson", colorsgc=colorant"orange")
+                     colorsrt=colorant"crimson", colorsgc=colorant"orange",
+                     darkmode=false)
     seeds = [colorbg, colorfont]
     function make_variations(color)
         color === nothing && return RGB{N0f8}[]
@@ -50,13 +51,14 @@ function FlameColors(n::Integer=2;
     colorsgc = make_variations(colorsgc)
     append!(seeds, colorsrt)
     append!(seeds, colorsgc)
+    darkmode && append!(seeds, make_variations(RGB(0.9,0.9,0.9))) # bias away from white
     nseeds = length(seeds)
     colors = distinguishable_colors(2n+nseeds, seeds,
                                     transform=c->deuteranopic(c, 0.95),
                                     lchoices=Float64[65, 80],
                                     cchoices=Float64[10, 55],
                                     hchoices=range(10, stop=350, length=18))[nseeds+1:end]
-    sort!(colors, by=c->colordiff(c, colorbg))
+    sort!(colors, by=c->colordiff(c, darkmode ? colorfont : colorbg))
     return FlameGraphs.FlameColors(colors, colorbg, colorfont, colorsrt, colorsgc)
 end
 

--- a/src/render.jl
+++ b/src/render.jl
@@ -63,6 +63,7 @@ function FlameColors(n::Integer=2;
 end
 
 const default_colors = FlameColors()
+const default_colors_dark = FlameColors(; colorbg=RGB(0.09,0.09,0.09), colorfont=colorant"white", darkmode = true)
 
 function (colors::FlameColors)(s::Symbol)
     s === :bg && return colors.colorbg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -414,6 +414,9 @@ end
     @test img[1,4] == fc2.colors[6]
     @test all(img[2:4,4] .== fc2.colorbg)
 
+    # dark mode
+    fc3 = FlameColors(;colorbg=RGB(0.09,0.09,0.09), colorfont=colorant"white", darkmode = true)
+
     sfc = StackFrameCategory()
     @test sfc(:bg) == sfc.colorbg
     @test_throws ArgumentError sfc(:unknown)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -415,7 +415,7 @@ end
     @test all(img[2:4,4] .== fc2.colorbg)
 
     # dark mode
-    fc3 = FlameColors(;colorbg=RGB(0.09,0.09,0.09), colorfont=colorant"white", darkmode = true)
+    fc3 = FlameColors(; darkmode = true)
 
     sfc = StackFrameCategory()
     @test sfc(:bg) == sfc.colorbg


### PR DESCRIPTION
Provides a dark mode for the color generator that biases the colors away from white.

Also provides `default_colors_dark` as a counter to `default_colors`.

I guess the general idea in dark modes is to prefer darker colors, so that's what this attempts.

How these look in https://github.com/timholy/ProfileView.jl/pull/193

<img width="804" alt="Screen Shot 2022-01-17 at 5 50 32 PM" src="https://user-images.githubusercontent.com/1694067/149845135-abcd8fef-ba04-4c9f-b149-c69169bf460f.png">



Without the biasing the colors get too washed out and the white text is harder to read.


<img width="809" alt="Screen Shot 2022-01-17 at 3 57 45 PM" src="https://user-images.githubusercontent.com/1694067/149845199-72ec12bd-ac8b-48ca-9c84-64cf7806cae9.png">


