### PR TITLE
Remove hard dependency on FileIO.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,11 +6,18 @@ version = "1.0.0"
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
-FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 IndirectArrays = "9b13fd28-a010-5f03-acff-a1bbcff69959"
 LeftChildRightSiblingTrees = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+
+[weakdeps]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+
+[extensions]
+FlameGraphsFileIOExt = ["FileIO"]
 
 [compat]
 AbstractTrees = "0.4"
@@ -19,11 +26,13 @@ FileIO = "1.6"
 FixedPointNumbers = "0.6.1, 0.7, 0.8"
 IndirectArrays = "0.5, 1.0"
 LeftChildRightSiblingTrees = "0.2"
+Requires = "1"
 julia = "1.6"
 
 [extras]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InteractiveUtils", "Test"]
+test = ["FileIO", "InteractiveUtils", "Test"]

--- a/ext/FlameGraphsFileIOExt.jl
+++ b/ext/FlameGraphsFileIOExt.jl
@@ -1,0 +1,38 @@
+module FlameGraphsFileIOExt
+
+isdefined(Base, :get_extension) ? (using FileIO) : (using ..FileIO)
+using Profile
+
+using FlameGraphs
+using FlameGraphs: Node, NodeData
+
+import FlameGraphs: save, load
+
+function save(f::File{format"JLPROF"}, data::AbstractVector{<:Unsigned}, lidict::Profile.LineInfoDict)
+    open(f, "w") do s
+        save(stream(s), data, lidict)
+    end
+end
+
+function save(f::File{format"JLPROF"}, g::Node{NodeData})
+    open(f, "w") do s
+        save(stream(s), g)
+    end
+end
+
+# Note: this may not work from FileIO because it returns an anonymous function for saving data
+save(f::File{format"JLPROF"}) = save(filename(f))
+
+
+function load(f::File{format"JLPROF"})
+    open(f) do s
+        skipmagic(s)
+        load(s)
+    end
+end
+
+function load(s::Stream{format"JLPROF"})
+    load(stream(s))
+end
+
+end # module FlameGraphsFileIOExt

--- a/src/FlameGraphs.jl
+++ b/src/FlameGraphs.jl
@@ -4,7 +4,10 @@ using Profile, LeftChildRightSiblingTrees
 using Base.StackTraces: StackFrame
 using Profile: StackFrameTree
 using Colors, FixedPointNumbers, IndirectArrays
-using FileIO
+
+@static if !isdefined(Base, :get_extension)
+    using Requires
+end
 
 # AbstractTree interface for StackFrameTree:
 using AbstractTrees
@@ -17,6 +20,12 @@ include("graph.jl")
 include("render.jl")
 include("sfcategory.jl")
 include("io.jl")
+
+@static if !isdefined(Base, :get_extension)
+    function __init__()
+        @require FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549" include("../ext/FlameGraphsFileIOExt.jl")
+    end
+end
 
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing


### PR DESCRIPTION
This is in preparation for issue #65.
Unlike Colors.jl, I believe it is possible to remove the hard dependency on FilesIO.jl in a compatible manner, i.e. in FlameGraphs.jl v1.
This is because `FilesIO` must be loaded in order to use `File{format "JLPROF"}`.

For compatibility this depends on Requires.jl instead. However, it had already been in the dependencies indirectly via FileIO.jl.