### PR TITLE
Use an IdDict for flametags to allow distinguishing different sf instances

### DIFF
--- a/src/render.jl
+++ b/src/render.jl
@@ -171,6 +171,8 @@ function flametags(g, img)
     tags = fill(1, axes(img))
     ndata = g.data
     sflist = StackFrame[StackTraces.UNKNOWN]
+    # use an IdDict so that equal stackframes from different places in the flamegraph can be
+    # distinguishable via egality
     sf2tag = IdDict{StackFrame,Int}(StackTraces.UNKNOWN=>1)
     tags[:,1] .= tagidx(ndata.sf, sf2tag, sflist)
     costscale = size(img, 1) / length(ndata.span)

--- a/src/render.jl
+++ b/src/render.jl
@@ -171,7 +171,7 @@ function flametags(g, img)
     tags = fill(1, axes(img))
     ndata = g.data
     sflist = StackFrame[StackTraces.UNKNOWN]
-    sf2tag = Dict{StackFrame,Int}(StackTraces.UNKNOWN=>1)
+    sf2tag = IdDict{StackFrame,Int}(StackTraces.UNKNOWN=>1)
     tags[:,1] .= tagidx(ndata.sf, sf2tag, sflist)
     costscale = size(img, 1) / length(ndata.span)
     flametags!(tags, g, sf2tag, sflist, 2, costscale)


### PR DESCRIPTION
Required for https://github.com/timholy/ProfileView.jl/pull/243