### PR TITLE
[compat]: LCRST 0.3, trim old versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlameGraphs"
 uuid = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -14,11 +14,11 @@ Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 
 [compat]
 AbstractTrees = "0.4"
-Colors = "0.9, 0.10, 0.11, 0.12, 0.13"
+Colors = "0.13"
 FileIO = "1.6"
-FixedPointNumbers = "0.6.1, 0.7, 0.8"
-IndirectArrays = "0.5, 1.0"
-LeftChildRightSiblingTrees = "0.2"
+FixedPointNumbers = "0.8"
+IndirectArrays = "1.0"
+LeftChildRightSiblingTrees = "0.2, 0.3"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
Many of the older versions were more than two years out of date, so it seems reasonable to require the latest.