### PR TITLE
Support the allocation profiler in `flamegraph`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'min'
           - '1'
           - 'nightly'
         os:
@@ -43,8 +43,6 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
-        with:
-          cache-registries: ${{ ! (matrix.version == '1.6' && matrix.os == 'windows-latest') }}
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FlameGraphs"
 uuid = "08572546-2f56-4bcf-ba4e-bab62c3a3f89"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ FileIO = "1.6"
 FixedPointNumbers = "0.8"
 IndirectArrays = "1.0"
 LeftChildRightSiblingTrees = "0.2, 0.3"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,6 +46,20 @@ Each node of the tree consists of a `StackFrame` indicating the file, function, 
 
 [`flamegraph`](@ref) has several options that can be used to control how it computes the graph.
 
+## Allocation profiles
+
+FlameGraphs can also represent data collected by Julia's [allocation profiler](https://docs.julialang.org/en/v1/stdlib/Profile/#Profile.Allocs.@profile) (`Profile.Allocs`, available on Julia 1.8 and later). Collect the data and pass the result of `Profile.Allocs.fetch()` to `flamegraph`:
+
+```julia
+using Profile, FlameGraphs
+
+Profile.Allocs.@profile profile_test(10)
+
+g = flamegraph(Profile.Allocs.fetch())
+```
+
+For an allocation flame graph, the width of each node measures memory allocation rather than run time: by default the number of bytes allocated, or the number of separate allocations with `mode=:count`. The leaf of each branch names the type of the allocated object. The resulting `g` is an ordinary flame graph and can be rendered exactly like a time profile.
+
 ## Rendering a flame graph
 
 You can create a "bitmap" representation of the flame graph with [`flamepixels`](@ref):

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -48,7 +48,7 @@ Each node of the tree consists of a `StackFrame` indicating the file, function, 
 
 ## Allocation profiles
 
-FlameGraphs can also represent data collected by Julia's [allocation profiler](https://docs.julialang.org/en/v1/stdlib/Profile/#Profile.Allocs.@profile) (`Profile.Allocs`, available on Julia 1.8 and later). Collect the data and pass the result of `Profile.Allocs.fetch()` to `flamegraph`:
+FlameGraphs can also represent data collected by Julia's [allocation profiler](https://docs.julialang.org/en/v1/stdlib/Profile/#Profile.Allocs.@profile) (`Profile.Allocs`). Collect the data and pass the result of `Profile.Allocs.fetch()` to `flamegraph`:
 
 ```julia
 using Profile, FlameGraphs

--- a/src/FlameGraphs.jl
+++ b/src/FlameGraphs.jl
@@ -14,7 +14,11 @@ AbstractTrees.printnode(io::IO, node::StackFrameTree) = print(io, node.frame)
 export flamegraph, flamepixels, flametags, FlameColors, StackFrameCategory
 
 include("graph.jl")
-include("allocs.jl")
+# `allocs.jl` uses syntax (`const` struct fields) and types (`Profile.Allocs`)
+# unavailable before Julia 1.8, so it must not even be parsed there.
+@static if isdefined(Profile, :Allocs)
+    include("allocs.jl")
+end
 include("render.jl")
 include("sfcategory.jl")
 include("io.jl")

--- a/src/FlameGraphs.jl
+++ b/src/FlameGraphs.jl
@@ -14,6 +14,7 @@ AbstractTrees.printnode(io::IO, node::StackFrameTree) = print(io, node.frame)
 export flamegraph, flamepixels, flametags, FlameColors, StackFrameCategory
 
 include("graph.jl")
+include("allocs.jl")
 include("render.jl")
 include("sfcategory.jl")
 include("io.jl")

--- a/src/FlameGraphs.jl
+++ b/src/FlameGraphs.jl
@@ -14,11 +14,7 @@ AbstractTrees.printnode(io::IO, node::StackFrameTree) = print(io, node.frame)
 export flamegraph, flamepixels, flametags, FlameColors, StackFrameCategory
 
 include("graph.jl")
-# `allocs.jl` uses syntax (`const` struct fields) and types (`Profile.Allocs`)
-# unavailable before Julia 1.8, so it must not even be parsed there.
-@static if isdefined(Profile, :Allocs)
-    include("allocs.jl")
-end
+include("allocs.jl")
 include("render.jl")
 include("sfcategory.jl")
 include("io.jl")

--- a/src/allocs.jl
+++ b/src/allocs.jl
@@ -1,0 +1,116 @@
+# Support for Julia's allocation profiler, `Profile.Allocs`.
+# Implements issues #52 and #70. The allocation profiler hands back already-decoded
+# stack traces (rather than instruction pointers), so the tree is built directly
+# instead of going through `Profile.tree!`.
+
+@static if isdefined(Profile, :Allocs)
+
+# An intermediate tree used while accumulating allocation weights. Identical
+# stackframes are merged, keyed by `framekey`.
+const AllocKey = Tuple{Symbol,Symbol,Int,Bool}
+
+mutable struct AllocTreeNode
+    sf::StackFrame
+    status::UInt8
+    weight::Int
+    children::Dict{AllocKey,AllocTreeNode}
+end
+AllocTreeNode(sf::StackFrame) = AllocTreeNode(sf, UInt8(0), 0, Dict{AllocKey,AllocTreeNode}())
+
+framekey(sf::StackFrame) = (sf.func, sf.file, sf.line, sf.from_c)
+
+# The leaf of each allocation branch names the type of the allocated object.
+# `Profile.Allocs` reports unknown types as `Profile.Allocs.UnknownType`; strip
+# the module qualifier so the leaf reads simply as `UnknownType`.
+alloctypename(@nospecialize(T)) = replace(string(T), "Profile.Allocs." => "")
+
+"""
+    g = flamegraph(allocs::Profile.Allocs.AllocResults; C=false, mode=:bytes, pruned=[], norepl=true, filter=nothing)
+
+Compute a flame graph from data collected by Julia's allocation profiler,
+`Profile.Allocs`. Collect the data with `Profile.Allocs.@profile`, then pass the
+result of `Profile.Allocs.fetch()`:
+
+```julia
+Profile.Allocs.@profile my_computation()
+g = flamegraph(Profile.Allocs.fetch())
+```
+
+The width of each node measures memory allocation. With `mode=:bytes` (the
+default) widths are the number of bytes allocated; with `mode=:count` they are
+the number of allocations. The leaf of each branch names the type of the
+allocated object.
+
+The keywords `C`, `pruned`, `norepl`, and `filter` behave as in the
+time-profiling [`flamegraph`](@ref) method.
+
+!!! compat "Julia 1.8"
+    The allocation profiler requires Julia 1.8 or later.
+"""
+function flamegraph(allocs::Profile.Allocs.AllocResults; C::Bool=false, mode::Symbol=:bytes,
+        pruned=defaultpruned, norepl::Bool=true, filter=nothing)
+    weightfun = if mode === :bytes
+        alloc -> Int(alloc.size)
+    elseif mode === :count
+        alloc -> 1
+    else
+        error("`mode` must be `:bytes` or `:count`, got ", repr(mode))
+    end
+
+    root = AllocTreeNode(StackFrame(Symbol("root"), Symbol(""), 0))
+    for alloc in allocs.allocs
+        w = weightfun(alloc)
+        root.weight += w
+        node = root
+        pruned_here = false
+        # `stacktrace` runs leaf-to-root; reverse it so we descend from the root.
+        for sf in Iterators.reverse(alloc.stacktrace)
+            if !C && sf.from_c
+                # Suppressed C frames still contribute their status to the caller.
+                node.status |= status(sf)
+                continue
+            end
+            if ispruned(sf, pruned)
+                pruned_here = true
+                break
+            end
+            child = get!(() -> AllocTreeNode(sf), node.children, framekey(sf))
+            child.status |= status(sf)
+            child.weight += w
+            node = child
+        end
+        pruned_here && continue
+        tname = alloctypename(alloc.type)
+        leaf = get!(() -> AllocTreeNode(StackFrame(Symbol(tname), Symbol(""), 0)),
+                    node.children, (Symbol(tname), Symbol(""), 0, false))
+        leaf.weight += w
+    end
+
+    if root.weight == 0
+        Profile.warning_empty()
+        return nothing
+    end
+
+    g = Node(NodeData(root.sf, root.status, 1:root.weight))
+    flamegraph_allocs!(g, root)
+    norepl && prunerepl!(g)
+    filter !== nothing && filtergraph!(g, filter)
+    return g
+end
+
+function flamegraph_allocs!(graph, atn::AllocTreeNode)
+    childnodes = collect(values(atn.children))
+    isempty(childnodes) && return graph
+    # Order siblings as the time-profiling flamegraph does, by location info.
+    p = Profile.liperm(StackFrame[c.sf for c in childnodes])
+    hstart = first(graph.data.span)
+    for i in p
+        child = childnodes[i]
+        cnode = addchild(graph, NodeData(child.sf, child.status, hstart:hstart+child.weight-1))
+        flamegraph_allocs!(cnode, child)
+        hstart += child.weight
+    end
+    return graph
+end
+
+end  # @static if isdefined(Profile, :Allocs)

--- a/src/allocs.jl
+++ b/src/allocs.jl
@@ -2,10 +2,6 @@
 # Implements issues #52 and #70. The allocation profiler hands back already-decoded
 # stack traces (rather than instruction pointers), so the tree is built directly
 # instead of going through `Profile.tree!`.
-#
-# This file is only `include`d on Julia 1.8+ (see FlameGraphs.jl); it must not be
-# parsed on earlier versions, where `Profile.Allocs` is absent and `const` struct
-# fields are a syntax error.
 
 # An intermediate tree used while accumulating allocation weights. Identical
 # stackframes are merged, keyed by `framekey`.
@@ -58,9 +54,6 @@ allocated object.
 
 The keywords `C`, `pruned`, `norepl`, and `filter` behave as in the
 time-profiling [`flamegraph`](@ref) method.
-
-!!! compat "Julia 1.8"
-    The allocation profiler requires Julia 1.8 or later.
 """
 function flamegraph(allocs::Profile.Allocs.AllocResults; C::Bool=false, mode::Symbol=:bytes,
         pruned=defaultpruned, norepl::Bool=true, filter=nothing)

--- a/src/allocs.jl
+++ b/src/allocs.jl
@@ -10,10 +10,10 @@
 const AllocKey = Tuple{Symbol,Symbol,Int,Bool}
 
 mutable struct AllocTreeNode
-    sf::StackFrame
+    const sf::StackFrame
     status::UInt8
     weight::Int
-    children::Dict{AllocKey,AllocTreeNode}
+    const children::Dict{AllocKey,AllocTreeNode}
 end
 AllocTreeNode(sf::StackFrame) = AllocTreeNode(sf, UInt8(0), 0, Dict{AllocKey,AllocTreeNode}())
 

--- a/src/allocs.jl
+++ b/src/allocs.jl
@@ -21,8 +21,21 @@ framekey(sf::StackFrame) = (sf.func, sf.file, sf.line, sf.from_c)
 
 # The leaf of each allocation branch names the type of the allocated object.
 # `Profile.Allocs` reports unknown types as `Profile.Allocs.UnknownType`; strip
-# the module qualifier so the leaf reads simply as `UnknownType`.
-alloctypename(@nospecialize(T)) = replace(string(T), "Profile.Allocs." => "")
+# the module qualifier so the leaf reads simply as `UnknownType`. Type names can
+# occasionally be enormous (deeply parametric types, large `NamedTuple`s); keep
+# the label bounded, retaining head and tail, so it stays readable in
+# `print_tree` and other renderers.
+const alloctypename_maxlen = 120
+
+function alloctypename(@nospecialize(T))
+    name = replace(string(T), "Profile.Allocs." => "")
+    if length(name) > alloctypename_maxlen
+        head = alloctypename_maxlen ÷ 2 - 1
+        tail = alloctypename_maxlen - head - 1
+        name = string(first(name, head), '…', last(name, tail))
+    end
+    return name
+end
 
 """
     g = flamegraph(allocs::Profile.Allocs.AllocResults; C=false, mode=:bytes, pruned=[], norepl=true, filter=nothing)

--- a/src/allocs.jl
+++ b/src/allocs.jl
@@ -2,8 +2,10 @@
 # Implements issues #52 and #70. The allocation profiler hands back already-decoded
 # stack traces (rather than instruction pointers), so the tree is built directly
 # instead of going through `Profile.tree!`.
-
-@static if isdefined(Profile, :Allocs)
+#
+# This file is only `include`d on Julia 1.8+ (see FlameGraphs.jl); it must not be
+# parsed on earlier versions, where `Profile.Allocs` is absent and `const` struct
+# fields are a syntax error.
 
 # An intermediate tree used while accumulating allocation weights. Identical
 # stackframes are merged, keyed by `framekey`.
@@ -125,5 +127,3 @@ function flamegraph_allocs!(graph, atn::AllocTreeNode)
     end
     return graph
 end
-
-end  # @static if isdefined(Profile, :Allocs)

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -55,8 +55,7 @@ profiling data, supply both. (`data` and `lidict` must be a matched pair from `P
 You can control the strategy with the following keywords:
 
 - `C`: if `true`, include stackframes collected from `ccall`ed code.
-- `recur` (supported on Julia 1.4+): represent recursive calls as if they corresponded to
-  iteration.
+- `recur`: represent recursive calls as if they corresponded to iteration.
 - `norepl`: if true, the portions of stacktraces deeper than `REPL.eval_user_input` are discarded.
 - `pruned`: a list of `(funcname, filename)` pairs that trigger the termination of this branch
   of the flame graph. You can use this to prevent very "tall" graphs from deeply-recursive
@@ -70,9 +69,6 @@ You can control the strategy with the following keywords:
   or ancestor.
 - `threads::Union{Int,AbstractVector{Int},Nothing}`: specify which threads to include samples from. `nothing` returns all.
 - `tasks::Union{Int,AbstractVector{Int},Nothing}`: specify which tasks to include samples from. `nothing` returns all.
-
-!!! compat "Julia 1.8"
-    The `threads` and `tasks` kwargs require Julia 1.8
 
 `g` can be inspected using [`AbstractTrees.jl`'s](https://github.com/JuliaCollections/AbstractTrees.jl)
 `print_tree`.
@@ -89,15 +85,9 @@ function flamegraph(data=Profile.fetch(); lidict::Union{Dict{UInt64,Vector{Base.
     # Build the tree with C=true, regardless of user setting. This is because
     # we need the C frames to set the status flag. They will be omitted by `flamegraph!`
     # as needed.
-    if VERSION >= v"1.8.0-DEV.460"
-        threads = something(threads, 1:Threads.nthreads())
-        tasks = something(tasks, typemin(UInt):typemax(UInt))
-        root, _ = Profile.tree!(root, data_u64, lidict, #= C =# true, recur, threads, tasks)
-    else
-        threads === nothing || error("Specifying `threads` is not supported before julia 1.8")
-        tasks === nothing || error("Specifying `tasks` is not supported before julia 1.8")
-        root = Profile.tree!(root, data_u64, lidict, #= C =# true, recur)
-    end
+    threads = something(threads, 1:Threads.nthreads())
+    tasks = something(tasks, typemin(UInt):typemax(UInt))
+    root, _ = Profile.tree!(root, data_u64, lidict, #= C =# true, recur, threads, tasks)
     if isempty(root.down)
         Profile.warning_empty()
         return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -530,66 +530,62 @@ end
     rm(fn)
 end
 
-# Issues #52 and #70.
-# `@static` is required: `Profile.Allocs.@profile` is a macro and would be
-# resolved at expansion time even inside a runtime `if`, erroring before Julia 1.8.
-@static if isdefined(Profile, :Allocs)
-    @testset "allocation profiler" begin
-        # Each child's span must immediately follow its previous sibling, starting
-        # at the parent's span; children may sum to less than the parent (self-weight).
-        function spansvalid(node)
-            kids = collect(node)
-            isempty(kids) && return true
-            s = first(node.data.span)
-            for k in kids
-                first(k.data.span) == s || return false
-                spansvalid(k) || return false
-                s = last(k.data.span) + 1
-            end
-            return last(kids).data.span[end] <= last(node.data.span)
+# Issues #52 and #70
+@testset "allocation profiler" begin
+    # Each child's span must immediately follow its previous sibling, starting
+    # at the parent's span; children may sum to less than the parent (self-weight).
+    function spansvalid(node)
+        kids = collect(node)
+        isempty(kids) && return true
+        s = first(node.data.span)
+        for k in kids
+            first(k.data.span) == s || return false
+            spansvalid(k) || return false
+            s = last(k.data.span) + 1
         end
-
-        alloc_workload() = [Vector{Float64}(undef, 4) for _ in 1:2000]
-
-        alloc_workload()  # compile
-        Profile.Allocs.clear()
-        Profile.Allocs.@profile sample_rate=1.0 alloc_workload()
-        results = Profile.Allocs.fetch()
-
-        g = flamegraph(results)
-        @test g !== nothing
-        @test first(g.data.span) == 1
-        @test length(g.data.span) == sum(a.size for a in results.allocs)
-        @test spansvalid(g)
-
-        # The leaf of every branch names the allocated type, with no location info.
-        leaves = [n for n in PostOrderDFS(g) if isempty(collect(n))]
-        @test !isempty(leaves)
-        @test all(l -> l.data.sf.file === Symbol("") && l.data.sf.line == 0, leaves)
-        @test any(l -> l.data.sf.func === Symbol("Vector{Float64}"), leaves)
-        @test any(n -> n.data.sf.func === :alloc_workload, PreOrderDFS(g))
-
-        # `mode=:count` weights each node by the number of allocations.
-        gc = flamegraph(results; mode=:count)
-        @test length(gc.data.span) == length(results.allocs)
-        @test spansvalid(gc)
-
-        # Suppressed C frames still account for all the allocated bytes.
-        gC = flamegraph(results; C=true)
-        @test length(gC.data.span) == length(g.data.span)
-        @test spansvalid(gC)
-
-        @test_throws "`mode` must be `:bytes` or `:count`" flamegraph(results; mode=:nope)
-
-        # Pathologically long type names are truncated so leaf labels stay readable.
-        bigtype = NamedTuple{ntuple(i -> Symbol(:field, i), 40), NTuple{40,Float64}}
-        @test length(string(bigtype)) > 200
-        short = FlameGraphs.alloctypename(bigtype)
-        @test length(short) <= 120
-        @test occursin('…', short)
-        @test FlameGraphs.alloctypename(Vector{Float64}) == "Vector{Float64}"
-
-        empty = Profile.Allocs.AllocResults(Profile.Allocs.Alloc[])
-        @test (@test_logs (:warn, r"There were no samples collected") flamegraph(empty)) === nothing
+        return last(kids).data.span[end] <= last(node.data.span)
     end
+
+    alloc_workload() = [Vector{Float64}(undef, 4) for _ in 1:2000]
+
+    alloc_workload()  # compile
+    Profile.Allocs.clear()
+    Profile.Allocs.@profile sample_rate=1.0 alloc_workload()
+    results = Profile.Allocs.fetch()
+
+    g = flamegraph(results)
+    @test g !== nothing
+    @test first(g.data.span) == 1
+    @test length(g.data.span) == sum(a.size for a in results.allocs)
+    @test spansvalid(g)
+
+    # The leaf of every branch names the allocated type, with no location info.
+    leaves = [n for n in PostOrderDFS(g) if isempty(collect(n))]
+    @test !isempty(leaves)
+    @test all(l -> l.data.sf.file === Symbol("") && l.data.sf.line == 0, leaves)
+    @test any(l -> l.data.sf.func === Symbol("Vector{Float64}"), leaves)
+    @test any(n -> n.data.sf.func === :alloc_workload, PreOrderDFS(g))
+
+    # `mode=:count` weights each node by the number of allocations.
+    gc = flamegraph(results; mode=:count)
+    @test length(gc.data.span) == length(results.allocs)
+    @test spansvalid(gc)
+
+    # Suppressed C frames still account for all the allocated bytes.
+    gC = flamegraph(results; C=true)
+    @test length(gC.data.span) == length(g.data.span)
+    @test spansvalid(gC)
+
+    @test_throws "`mode` must be `:bytes` or `:count`" flamegraph(results; mode=:nope)
+
+    # Pathologically long type names are truncated so leaf labels stay readable.
+    bigtype = NamedTuple{ntuple(i -> Symbol(:field, i), 40), NTuple{40,Float64}}
+    @test length(string(bigtype)) > 200
+    short = FlameGraphs.alloctypename(bigtype)
+    @test length(short) <= 120
+    @test occursin('…', short)
+    @test FlameGraphs.alloctypename(Vector{Float64}) == "Vector{Float64}"
+
+    empty = Profile.Allocs.AllocResults(Profile.Allocs.Alloc[])
+    @test (@test_logs (:warn, r"There were no samples collected") flamegraph(empty)) === nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -530,8 +530,10 @@ end
     rm(fn)
 end
 
-# Issues #52 and #70
-if isdefined(Profile, :Allocs)
+# Issues #52 and #70.
+# `@static` is required: `Profile.Allocs.@profile` is a macro and would be
+# resolved at expansion time even inside a runtime `if`, erroring before Julia 1.8.
+@static if isdefined(Profile, :Allocs)
     @testset "allocation profiler" begin
         # Each child's span must immediately follow its previous sibling, starting
         # at the parent's span; children may sum to less than the parent (self-weight).
@@ -578,6 +580,14 @@ if isdefined(Profile, :Allocs)
         @test spansvalid(gC)
 
         @test_throws "`mode` must be `:bytes` or `:count`" flamegraph(results; mode=:nope)
+
+        # Pathologically long type names are truncated so leaf labels stay readable.
+        bigtype = NamedTuple{ntuple(i -> Symbol(:field, i), 40), NTuple{40,Float64}}
+        @test length(string(bigtype)) > 200
+        short = FlameGraphs.alloctypename(bigtype)
+        @test length(short) <= 120
+        @test occursin('…', short)
+        @test FlameGraphs.alloctypename(Vector{Float64}) == "Vector{Float64}"
 
         empty = Profile.Allocs.AllocResults(Profile.Allocs.Alloc[])
         @test (@test_logs (:warn, r"There were no samples collected") flamegraph(empty)) === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -529,3 +529,57 @@ end
     @test nodeeq(g, gr)
     rm(fn)
 end
+
+# Issues #52 and #70
+if isdefined(Profile, :Allocs)
+    @testset "allocation profiler" begin
+        # Each child's span must immediately follow its previous sibling, starting
+        # at the parent's span; children may sum to less than the parent (self-weight).
+        function spansvalid(node)
+            kids = collect(node)
+            isempty(kids) && return true
+            s = first(node.data.span)
+            for k in kids
+                first(k.data.span) == s || return false
+                spansvalid(k) || return false
+                s = last(k.data.span) + 1
+            end
+            return last(kids).data.span[end] <= last(node.data.span)
+        end
+
+        alloc_workload() = [Vector{Float64}(undef, 4) for _ in 1:2000]
+
+        alloc_workload()  # compile
+        Profile.Allocs.clear()
+        Profile.Allocs.@profile sample_rate=1.0 alloc_workload()
+        results = Profile.Allocs.fetch()
+
+        g = flamegraph(results)
+        @test g !== nothing
+        @test first(g.data.span) == 1
+        @test length(g.data.span) == sum(a.size for a in results.allocs)
+        @test spansvalid(g)
+
+        # The leaf of every branch names the allocated type, with no location info.
+        leaves = [n for n in PostOrderDFS(g) if isempty(collect(n))]
+        @test !isempty(leaves)
+        @test all(l -> l.data.sf.file === Symbol("") && l.data.sf.line == 0, leaves)
+        @test any(l -> l.data.sf.func === Symbol("Vector{Float64}"), leaves)
+        @test any(n -> n.data.sf.func === :alloc_workload, PreOrderDFS(g))
+
+        # `mode=:count` weights each node by the number of allocations.
+        gc = flamegraph(results; mode=:count)
+        @test length(gc.data.span) == length(results.allocs)
+        @test spansvalid(gc)
+
+        # Suppressed C frames still account for all the allocated bytes.
+        gC = flamegraph(results; C=true)
+        @test length(gC.data.span) == length(g.data.span)
+        @test spansvalid(gC)
+
+        @test_throws "`mode` must be `:bytes` or `:count`" flamegraph(results; mode=:nope)
+
+        empty = Profile.Allocs.AllocResults(Profile.Allocs.Alloc[])
+        @test (@test_logs (:warn, r"There were no samples collected") flamegraph(empty)) === nothing
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,13 +25,8 @@ stackframe(func, file, line; C=false) = StackFrame(Symbol(func), Symbol(file), l
                                      7=>stackframe(:f1, :file1, 2),
                                      8=>stackframe(:f6, :file3, 10))
     for threads in [nothing, dummy_thread], tasks in [nothing, dummy_task]
-        VERSION < v"1.8.0-DEV.460" && threads !== nothing && tasks !== nothing && continue # skip if threads not available
         @testset "Threads: $(repr(threads)), Tasks: $(repr(tasks))" begin
-            g = if VERSION >= v"1.8.0-DEV.460"
-                flamegraph(backtraces; lidict=lidict, threads=threads, tasks=tasks)
-            else
-                flamegraph(backtraces; lidict=lidict)
-            end
+            g = flamegraph(backtraces; lidict=lidict, threads=threads, tasks=tasks)
             @test all(node->node.data.status == 0, PostOrderDFS(g))
             level1 = collect(g)
             @test length(level1) == 2


### PR DESCRIPTION
Add a `flamegraph` method for `Profile.Allocs.AllocResults`, so data from Julia's allocation profiler can be turned into a flame graph and rendered with the existing machinery. Node width measures memory (bytes by default, or allocation count with `mode=:count`), and the leaf of each branch names the type of the allocated object.

closes #52, closes #70