### PR TITLE
CI: fix macOS arch for Apple Silicon runners

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-docdeploy@latest
+      - uses: julia-actions/cache@v4
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
-      - uses: julia-actions/cache@v4
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -22,26 +22,15 @@ jobs:
         version:
           - 'min'
           - '1'
-          - 'nightly'
         os:
           - ubuntu-latest
-          - macos-13
+          - macos-latest
           - windows-latest
-        arch:
-          - x64
-        include:
-          - os: macos-latest
-            version: '1'
-            arch: aarch64
-          - os: macos-latest
-            version: 'nightly'
-            arch: aarch64
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -431,13 +431,22 @@ end
     A = randn(100, 100, 200)
     Profile.clear()
     mapslices(sum, A; dims=2)  # compile it so we don't end up profiling inference
+    # Sample finely so fast machines collect enough deep stacks to exceed the
+    # depth threshold below. Windows enforces a coarser minimum interval than
+    # other platforms, so this requested delay is a floor, not a guarantee.
+    n, delay = Profile.init()
+    Profile.init(; n, delay = 0.0001)
     g = nothing
-    for _ in 1:10
-        @profile mapslices(sum, A; dims=2)
-        g = flamegraph()
-        (g !== nothing && FlameGraphs.depth(g) > 10) && break
+    try
+        for _ in 1:10
+            @profile mapslices(sum, A; dims=2)
+            g = flamegraph()
+            (g !== nothing && FlameGraphs.depth(g) > 5) && break
+        end
+    finally
+        Profile.init(; n, delay)
     end
-    @test FlameGraphs.depth(g) > 10
+    @test FlameGraphs.depth(g) > 5
     img = flamepixels(StackFrameCategory(), flamegraph(C=true))
     @test any(img .== colorant"orange")
     A = [1,2,3]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -434,26 +434,28 @@ end
     # Sample finely so fast machines collect enough deep stacks to exceed the
     # depth threshold below. Windows enforces a coarser minimum interval than
     # other platforms, so this requested delay is a floor, not a guarantee.
+    # `Profile.init` clears the sample buffer, so restore the delay only after
+    # the last read of the buffer below.
     n, delay = Profile.init()
     Profile.init(; n, delay = 0.0001)
-    g = nothing
     try
+        g = nothing
         for _ in 1:10
             @profile mapslices(sum, A; dims=2)
             g = flamegraph()
             (g !== nothing && FlameGraphs.depth(g) > 5) && break
         end
+        @test FlameGraphs.depth(g) > 5
+        img = flamepixels(StackFrameCategory(), flamegraph(C=true))
+        @test any(img .== colorant"orange")
+        A = [1,2,3]
+        sum(A)
+        Profile.clear()
+        @profile sum(A)
+        Sys.islinux() && @test_logs (:warn, r"There were no samples collected.") flamegraph() === nothing
     finally
         Profile.init(; n, delay)
     end
-    @test FlameGraphs.depth(g) > 5
-    img = flamepixels(StackFrameCategory(), flamegraph(C=true))
-    @test any(img .== colorant"orange")
-    A = [1,2,3]
-    sum(A)
-    Profile.clear()
-    @profile sum(A)
-    Sys.islinux() && @test_logs (:warn, r"There were no samples collected.") flamegraph() === nothing
 end
 
 @testset "Runtime dipatch detection" begin


### PR DESCRIPTION
`macOS-latest` GitHub runners are now Apple Silicon (arm64). `setup-julia@v3` errors when `arch: x64` is requested on them, so the macOS jobs fail.

This configures the matrix to use the correct native architecture (default per-runner for single-arch matrices; explicit `exclude`/`include` for multi-arch matrices) and bumps `julia-actions/setup-julia` to v3.
